### PR TITLE
refactor!: '0' fields in enum Foo should be named `FOO_UNSPECIFIED`

### DIFF
--- a/protobuf/traits/air_quality_sensor.proto
+++ b/protobuf/traits/air_quality_sensor.proto
@@ -43,7 +43,7 @@ message AirQuality {
   // Comfort encodes levels of comfort for an area.
   enum Comfort {
     // The comfort level is unknown
-    UNKNOWN = 0;
+    COMFORT_UNSPECIFIED = 0;
     // The area should be comfortable for occupants
     COMFORTABLE = 1;
     // The area might be uncomfortable for occupants

--- a/protobuf/traits/air_temperature.proto
+++ b/protobuf/traits/air_temperature.proto
@@ -61,7 +61,7 @@ message AirTemperature {
   enum Mode {
     // The mode is unknown during a query. If used during a write then no change will be made, if part of a
     // read then the mode is unknown. This makes no sense as part of an attribute.
-    UNKNOWN = 0;
+    MODE_UNSPECIFIED = 0;
     // Write-only. If the device is OFF restore it to it's previous state
     ON = 1;
     // Attr, read, write. The device supports, is, or should be disabled

--- a/protobuf/traits/booking.proto
+++ b/protobuf/traits/booking.proto
@@ -76,7 +76,7 @@ message BookingSupport {
 
   enum CheckInSupport {
     // check in support is unknown
-    UNKNOWN = 0;
+    CHECK_IN_SUPPORT_UNSPECIFIED = 0;
     // check in is not supported
     NO_SUPPORT = 1;
     // check in is supported as a state, without an associated time

--- a/protobuf/traits/emergency.proto
+++ b/protobuf/traits/emergency.proto
@@ -46,7 +46,7 @@ message Emergency {
   // Levels of emergency
   enum Level {
     // The level is unknown, applications may choose to be cautious or care-free with this lack of information.
-    UNKNOWN = 0;
+    LEVEL_UNSPECIFIED = 0;
     // There is no emergency.
     OK = 1;
     // There is a chance of an emergency soon. This might be reported by a smoke detector that has detected some particles

--- a/protobuf/traits/energy_storage.proto
+++ b/protobuf/traits/energy_storage.proto
@@ -119,7 +119,7 @@ message EnergyLevel {
     // Threshold defines preset descriptive quantities for the energy level of the device.
     // Numeric values will be preferred if provided.
     enum Threshold {
-      THRESHOLD_UNKNOWN = 0;
+      THRESHOLD_UNSPECIFIED = 0;
       CRITICALLY_LOW = 1;
       EMPTY = 2;
       LOW = 3;

--- a/protobuf/traits/fan_speed.proto
+++ b/protobuf/traits/fan_speed.proto
@@ -48,7 +48,7 @@ message FanSpeed {
   int32 preset_index = 3;
 
   enum Direction {
-    DIRECTION_UNKNOWN = 0;
+    DIRECTION_UNSPECIFIED = 0;
     FORWARD = 1;
     BACKWARD = 2;
   }

--- a/protobuf/traits/input_select.proto
+++ b/protobuf/traits/input_select.proto
@@ -65,15 +65,17 @@ message InputSupport {
 
   // possible modes an input select device can
   enum Feature {
+    // The feature is not specified
+    FEATURE_UNSPECIFIED = 0;
     // both audio and video are treated as one. independent_av should be considered false in this mode
-    AV = 0;
+    AV = 1;
     // Only audio inputs are supported
-    AUDIO_ONLY = 1;
+    AUDIO_ONLY = 2;
     // Only video inputs are supported
-    VIDEO_ONLY = 2;
+    VIDEO_ONLY = 3;
     // Audio and video are both supported and can be selected independently if desired. The independent_av property can
     // be true in this mode only
-    INDEPENDENT = 3;
+    INDEPENDENT = 4;
   }
 }
 

--- a/protobuf/traits/metadata.proto
+++ b/protobuf/traits/metadata.proto
@@ -146,7 +146,7 @@ message Metadata {
     repeated string dns = 6;
 
     enum Assignment {
-      ASSIGNMENT_UNKNOWN = 0;
+      ASSIGNMENT_UNSPECIFIED = 0;
       DHCP = 1;
       STATIC = 2;
     }

--- a/protobuf/traits/motion_sensor.proto
+++ b/protobuf/traits/motion_sensor.proto
@@ -39,10 +39,12 @@ message MotionDetection {
 
   // Possible states for motion detected
   enum State {
+    // The state has not been specified.
+    STATE_UNSPECIFIED = 0;
     // No motion is detected, or has been detected within the not_detected_delay period
-    NOT_DETECTED = 0;
+    NOT_DETECTED = 1;
     // Motion has been detected by the device.
-    DETECTED = 1;
+    DETECTED = 2;
   }
 }
 

--- a/protobuf/traits/occupancy_sensor.proto
+++ b/protobuf/traits/occupancy_sensor.proto
@@ -53,7 +53,7 @@ message Occupancy {
   // Possible states for occupancy
   enum State {
     // There are no signals to suggest either an occupied or unoccupied space
-    NO_SIGNALS = 0;
+    STATE_UNSPECIFIED = 0;
     // The space is occupied
     OCCUPIED = 1;
     // The space is unoccupied

--- a/protobuf/traits/on_off.proto
+++ b/protobuf/traits/on_off.proto
@@ -35,7 +35,7 @@ message OnOff {
 
   // Possible states for an On-Off device
   enum State {
-    UNKNOWN = 0;
+    STATE_UNSPECIFIED = 0;
     ON = 1;
     OFF = 2;
   }

--- a/protobuf/traits/open_close.proto
+++ b/protobuf/traits/open_close.proto
@@ -55,7 +55,7 @@ message OpenClosePosition {
 
   // Possible directions the device can open/close
   enum Direction {
-    UNSPECIFIED = 0;
+    DIRECTION_UNSPECIFIED = 0;
     UP = 1;
     DOWN = 2;
     LEFT = 3;

--- a/protobuf/types/change.proto
+++ b/protobuf/types/change.proto
@@ -11,7 +11,7 @@ option java_package = "dev.smartcore.types";
 // Type of change
 enum ChangeType {
   // Nothing has changed but existing items have been requested. The new_value property should be set
-  NONE = 0;
+  CHANGE_TYPE_UNSPECIFIED = 0;
   // An item has been added. The new_value property of the change should be set
   ADD = 1;
   // An item has been updated. The new_value and old_value properties of the change should be set

--- a/protobuf/types/connection.proto
+++ b/protobuf/types/connection.proto
@@ -15,12 +15,14 @@ option java_package = "dev.smartcore.types";
 // The state of DISCONNECTED is not automatically an indication if issues in a system. A device may decide to disconnect
 // to save resources.
 enum Connectivity {
+  // The connection state has not been provided.
+  CONNECTIVITY_UNSPECIFIED = 0;
   // The concept of a connection makes no sense for this device
-  NOT_APPLICABLE = 0;
+  NOT_APPLICABLE = 1;
   // There is no active connection
-  DISCONNECTED = 1;
+  DISCONNECTED = 2;
   // There is an open connection to the device
-  CONNECTED = 2;
+  CONNECTED = 3;
 }
 
 // Describes the state of communication between two entities. the CommStatus typically represents the application layer
@@ -28,7 +30,7 @@ enum Connectivity {
 // application protocol response are never received then the CommStatus should not be COMM_SUCCESS.
 enum CommStatus {
   // the status of the line is unknown or unknowable
-  COMM_UNKNOWN = 0;
+  COMM_STATUS_UNSPECIFIED = 0;
   // The last time we attempted communication across it was successful.
   COMM_SUCCESS = 1;
   // Communication with the device is failing

--- a/protobuf/types/info.proto
+++ b/protobuf/types/info.proto
@@ -39,7 +39,7 @@ message ResourceSupport {
 // PullSupport describes how Pull methods are implemented by the server
 enum PullSupport {
   // How subscriptions are implemented is not known.
-  PULL_SUPPORT_UNKNOWN = 0;
+  PULL_SUPPORT_UNSPECIFIED = 0;
   // Subscribing is supported natively by the underlying system.
   PULL_SUPPORT_NATIVE = 1;
   // Subscribing is supported in the driver, rather than natively.

--- a/protobuf/types/number.proto
+++ b/protobuf/types/number.proto
@@ -14,7 +14,7 @@ import "types/tween.proto";
 // Possible behaviours for values that are not allowed by the number
 enum InvalidNumberBehaviour {
   // A default behaviour will be applied, typically RESTRICT
-  UNSPECIFIED = 0;
+  INVALID_NUMBER_BEHAVIOUR_UNSPECIFIED = 0;
   // The value will be restricted to the most appropriate value, typically the closest
   RESTRICT = 1;
   // An error will be raised to alert to the invalid value

--- a/protobuf/types/time/unit.proto
+++ b/protobuf/types/time/unit.proto
@@ -10,16 +10,17 @@ option java_package = "dev.smartcore.types.time";
 
 // Units of time
 enum Unit {
+  UNIT_UNSPECIFIED = 0;
   // seconds is the SI unit of time
-  UNIT_SECONDS = 0;
-  UNIT_MICROSECONDS = 1;
-  UNIT_MILLISECONDS = 2;
-  UNIT_NANOSECONDS = 3;
+  UNIT_SECONDS = 1;
+  UNIT_MICROSECONDS = 2;
+  UNIT_MILLISECONDS = 3;
+  UNIT_NANOSECONDS = 4;
 
-  UNIT_YEARS = 4;
-  UNIT_MONTHS = 5;
-  UNIT_WEEKS = 6;
-  UNIT_DAYS = 7;
-  UNIT_HOURS = 8;
-  UNIT_MINUTES = 9;
+  UNIT_YEARS = 5;
+  UNIT_MONTHS = 6;
+  UNIT_WEEKS = 7;
+  UNIT_DAYS = 8;
+  UNIT_HOURS = 9;
+  UNIT_MINUTES = 10;
 }

--- a/protobuf/types/tween.proto
+++ b/protobuf/types/tween.proto
@@ -13,16 +13,18 @@ import "google/protobuf/duration.proto";
 // Denote different types of tween support. Clients may use this to control performance sensitive areas by enabling or
 // disabling tweening when support is not native, for example
 enum TweenSupport {
+  // Tween support is not specified.
+  TWEEN_SUPPORT_UNSPECIFIED = 0;
   // The device does not support tweening
-  NO_SUPPORT = 0;
+  NO_SUPPORT = 1;
   // The device natively supports tweening. Natively typically means with minimal performance impact (i.e. no network)
-  NATIVE = 1;
+  NATIVE = 2;
   // The device supports tweening via emulation. Typically tweening is implemented by the Smart Core driver or a
   // supervisor node and not the device itself.
-  EMULATED = 2;
+  EMULATED = 3;
   // The device tweens values, but the duration or rate is fixed and cannot be adjusted. For example a motor might only
   // have one speed when operating an adjustable desk
-  FIXED = 3;
+  FIXED = 4;
 }
 
 // An in-progress transition between two values. The values themselves should be defined in an enclosing message.

--- a/protobuf/types/unit.proto
+++ b/protobuf/types/unit.proto
@@ -13,9 +13,10 @@ import "types/tween.proto";
 
 // Possible temperature units for physical bodies.
 enum TemperatureUnit {
-  CELSIUS = 0;
-  FAHRENHEIT = 1;
-  KELVIN = 2;
+  TEMPERATURE_UNIT_UNSPECIFIED = 0;
+  CELSIUS = 1;
+  FAHRENHEIT = 2;
+  KELVIN = 3;
 }
 
 // A temperature value
@@ -50,8 +51,9 @@ message AudioLevelChange {
 
 // What is the level of mute support that the speaker provides
 enum MuteSupport {
+  MUTE_SUPPORT_UNSPECIFIED = 0;
   // The speaker natively supports mute
-  MUTE_NATIVE = 0;
+  MUTE_NATIVE = 1;
   // Muting is emulated, typically by setting the gain to 0
-  MUTE_EMULATED = 1;
+  MUTE_EMULATED = 2;
 }


### PR DESCRIPTION
Most changes are wire compatible (i.e. only change the generated symbol named).

The following change the enum numbers and are wire incompatible:

 - input select: InputSupport.Feature
 - motion sensor: MotionDetection.State
 - types: Connectivity
 - types: TweenSupport
 - types: TemperatureUnit
 - types: MuteSupport
 - types/time: Unit