### PR TITLE
feat: Publication trait

### DIFF
--- a/protobuf/traits/publication.proto
+++ b/protobuf/traits/publication.proto
@@ -35,6 +35,7 @@ service PublicationApi {
   // they differ enabling multiple concurrent uses of this API.
   rpc DeletePublication(DeletePublicationRequest) returns (Publication);
   // Subscribe to changes for a single publication.
+  // The stream is closed if the publication is deleted.
   rpc PullPublication(PullPublicationRequest) returns (stream PullPublicationResponse);
 
   // List all publications available on the device.


### PR DESCRIPTION
Add a new Publication trait to describe devices that are able to store and manage a collection of published and versioned documents.

The intended use for this trait is to allow central management of configuration data, though the trait is flexible enough to potentially allow devices to use it for their own configuration information too.