### PR TITLE
npm: migrate to Github Packages

### DIFF
--- a/grpc-web/package.json
+++ b/grpc-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smart-core-os/sc-api-grpc-web",
-  "version": "1.0.0-beta.45",
+  "version": "1.0.0-beta.46",
   "description": "grpc-web client library",
   "license": "MIT",
   "dependencies": {
@@ -13,7 +13,7 @@
     "directory": "grpc-web"
   },
   "publishConfig": {
-    "registry": "https://nexus.vanti.co.uk/repository/npm-releases/"
+    "registry": "https://npm.pkg.github.com/"
   },
   "exports": {
     ".": "./index.js",

--- a/node/package.json
+++ b/node/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@smart-core-os/sc-api",
-  "version": "1.0.0-beta.45",
+  "version": "1.0.0-beta.46",
   "description": "Node.JS smart core server implementation",
-  "license": "AGPL-3.0",
+  "license": "MIT",
   "scripts": {
     "gen": "cp -r ../protobuf/* ./proto"
   },
@@ -12,6 +12,6 @@
     "directory": "node"
   },
   "publishConfig": {
-    "registry": "https://nexus.vanti.co.uk/repository/npm-releases/"
+    "registry": "https://npm.pkg.github.com/"
   }
 }


### PR DESCRIPTION
Bump version number (because of change to registry in package.json)

Change registry to Github Packages - this is publicly accessible which is what we want for a public repo like this.

Correct license in node to MIT - it must have been missed when the repo license changed.

I've already published these packages to check that it works, seems to be fine.